### PR TITLE
Remove Font Settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # vscode-dark-plus-webstorm
-VSCode Dark+ colourings for WebStorm (theme coming as soon as I find the time - until then, the colourings pair alright with Darcula).
+VSCode Dark+ colourings for WebStorm.
 
 ## Use
 
@@ -17,7 +17,7 @@ __TODO__
 * Diff & Merge
 * VCS
 
-__NOT DONE__ _(and unlikely to get done, as I'm not installing new languages for VSCode that I won't use)_
+__NOT DONE__
 * Cucumber
 * Dart
 * EJS
@@ -29,8 +29,6 @@ __NOT DONE__ _(and unlikely to get done, as I'm not installing new languages for
 * Spy-is
 
 ## Disclaimer
-This is a project I care about for as long as I am being forced to use WebStorm. I do not like WebStorm, and will not maintain either the colourings or theme when I can go back to an IDE of my choosing.
-
 The vast majority of work has been done with WebStorm open next to VSCode and its DevTools, selecting elements in VSCode and copying colour values where WebStorm does not match. As such, neither colourings nor theme are an exact replica (and never will be - VSCode and WebStorm handle a lot of things differently. VSCode, for example, offers far more granular syntax highlighting).
 
-Pull requests welcome.
+This project is not actively maintained, as WebStorm is not my IDE of choice. Pull requests are welcome.

--- a/README.md
+++ b/README.md
@@ -32,3 +32,7 @@ __NOT DONE__
 The vast majority of work has been done with WebStorm open next to VSCode and its DevTools, selecting elements in VSCode and copying colour values where WebStorm does not match. As such, neither colourings nor theme are an exact replica (and never will be - VSCode and WebStorm handle a lot of things differently. VSCode, for example, offers far more granular syntax highlighting).
 
 This project is not actively maintained, as WebStorm is not my IDE of choice. Pull requests are welcome.
+
+## Contributors and Thanks
+### Thanks
+* Zhan Ishzhanov ([janat08](https://github.com/janat08)) - for flagging font differences across platforms

--- a/vscode dark+.icls
+++ b/vscode dark+.icls
@@ -1,15 +1,11 @@
 <scheme name="vscode dark+" version="142" parent_scheme="Default">
-  <option name="FONT_SCALE" value="1.25" />
   <metaInfo>
-    <property name="created">2017-07-31T22:13:23</property>
+    <property name="created">2018-11-09T12:29:26</property>
     <property name="ide">WebStorm</property>
-    <property name="ideVersion">2017.2.0.0</property>
-    <property name="modified">2017-08-08T23:26:06</property>
+    <property name="ideVersion">2018.2.5.0.0</property>
+    <property name="modified">2018-11-09T12:29:41</property>
+    <property name="originalScheme">vscode dark+</property>
   </metaInfo>
-  <option name="EDITOR_FONT_SIZE" value="12" />
-  <option name="EDITOR_FONT_NAME" value="Monospaced" />
-  <option name="CONSOLE_FONT_NAME" value="DejaVu Sans Mono" />
-  <option name="CONSOLE_FONT_SIZE" value="15" />
   <colors>
     <option name="ADDED_LINES_COLOR" value="295622" />
     <option name="ANNOTATIONS_COLOR" value="8b999f" />


### PR DESCRIPTION
As determined in https://github.com/lenny1882/vscode-dark-plus-webstorm/pull/1, VSC and WS use different default fonts across platforms.

This update removes the font settings from the colourings file, to prevent one set of fonts (e.g. the Ubuntu fonts) being set as the font for all platforms.